### PR TITLE
FT: Nft attribute revamp, include attributes to class and asset data

### DIFF
--- a/pallets/auction/src/mock.rs
+++ b/pallets/auction/src/mock.rs
@@ -1,18 +1,20 @@
 #![cfg(test)]
 
-use super::*;
-use crate as auction;
+use frame_support::traits::Nothing;
 use frame_support::{construct_runtime, pallet_prelude::Hooks, parameter_types, PalletId};
+use frame_system::EnsureRoot;
 use orml_traits::parameter_type_with_key;
-use primitives::{continuum::Continuum, estate::Estate, Amount, AuctionId, EstateId, FungibleTokenId};
 use sp_core::H256;
 use sp_runtime::traits::AccountIdConversion;
 use sp_runtime::{testing::Header, traits::IdentityLookup};
 
 use auction_manager::{CheckAuctionItemHandler, ListingLevel};
 use bc_primitives::{MetaverseInfo, MetaverseTrait};
-use frame_support::traits::Nothing;
-use frame_system::EnsureRoot;
+use primitives::{continuum::Continuum, estate::Estate, Amount, AuctionId, EstateId, FungibleTokenId};
+
+use crate as auction;
+
+use super::*;
 
 parameter_types! {
 	pub const BlockHashCount: u32 = 256;
@@ -263,8 +265,7 @@ parameter_types! {
 
 impl pallet_nft::Config for Runtime {
 	type Event = Event;
-	type CreateClassDeposit = CreateClassDeposit;
-	type CreateAssetDeposit = CreateAssetDeposit;
+	type DataDepositPerByte = CreateAssetDeposit;
 	type Currency = Balances;
 	type PalletId = NftPalletId;
 	type WeightInfo = ();
@@ -275,9 +276,6 @@ impl pallet_nft::Config for Runtime {
 	type MultiCurrency = Currencies;
 	type MiningResourceId = MiningCurrencyId;
 	type PromotionIncentive = PromotionIncentive;
-	//	type PalletsOrigin = OriginCaller;
-	//	type TimeCapsuleDispatch = Call;
-	//	type TimeCapsuleScheduler = Scheduler;
 }
 
 parameter_types! {

--- a/pallets/auction/src/tests.rs
+++ b/pallets/auction/src/tests.rs
@@ -1,10 +1,13 @@
 #![cfg(test)]
 
-use super::*;
-use auction_manager::ListingLevel;
 use frame_support::{assert_noop, assert_ok};
+use sp_std::collections::btree_map::BTreeMap;
+
+use auction_manager::ListingLevel;
 use mock::{Event, *};
-use pallet_nft::{CollectionType, TokenType};
+use pallet_nft::{Attributes, CollectionType, TokenType};
+
+use super::*;
 
 fn init_test_nft(owner: Origin) {
 	//Create group collection before class
@@ -13,6 +16,7 @@ fn init_test_nft(owner: Origin) {
 	assert_ok!(NFTModule::<Runtime>::create_class(
 		owner.clone(),
 		vec![1],
+		test_attributes(1),
 		COLLECTION_ID,
 		TokenType::Transferable,
 		CollectionType::Collectable,
@@ -22,10 +26,15 @@ fn init_test_nft(owner: Origin) {
 		owner.clone(),
 		CLASS_ID,
 		vec![1],
-		vec![1],
-		vec![1],
+		test_attributes(1),
 		1
 	));
+}
+
+fn test_attributes(x: u8) -> Attributes {
+	let mut attr: Attributes = BTreeMap::new();
+	attr.insert(vec![x, x + 5], vec![x, x + 10]);
+	attr
 }
 
 #[test]
@@ -144,6 +153,7 @@ fn create_auction_fail() {
 		assert_ok!(NFTModule::<Runtime>::create_class(
 			owner.clone(),
 			vec![1],
+			Default::default(),
 			COLLECTION_ID,
 			TokenType::Transferable,
 			CollectionType::Collectable,
@@ -153,8 +163,7 @@ fn create_auction_fail() {
 			owner.clone(),
 			CLASS_ID,
 			vec![1],
-			vec![1],
-			vec![1],
+			Default::default(),
 			1
 		));
 		//account does not have permission to create auction
@@ -174,6 +183,7 @@ fn create_auction_fail() {
 		assert_ok!(NFTModule::<Runtime>::create_class(
 			owner.clone(),
 			vec![1],
+			Default::default(),
 			COLLECTION_ID,
 			TokenType::BoundToAddress,
 			CollectionType::Collectable,
@@ -183,8 +193,7 @@ fn create_auction_fail() {
 			owner.clone(),
 			1,
 			vec![1],
-			vec![1],
-			vec![1],
+			Default::default(),
 			1
 		));
 
@@ -411,8 +420,8 @@ fn asset_transfers_after_auction() {
 		);
 
 		// Verify transfer of fund (minus gas)
-		// BOB only receive 697 - 2 (1% of 200 as loyalty fee) = 695
-		assert_eq!(Balances::free_balance(BOB), 695);
+		// BOB only receive 200 - 2 (1% of 200 as loyalty fee) - 4 minting fee =
+		assert_eq!(Balances::free_balance(BOB), 690);
 		assert_eq!(Balances::free_balance(ALICE), 99800);
 
 		// Verify Alice has the NFT and Bob doesn't
@@ -473,8 +482,7 @@ fn buy_now_work() {
 			owner.clone(),
 			CLASS_ID,
 			vec![1],
-			vec![1],
-			vec![1],
+			Default::default(),
 			1
 		));
 
@@ -497,8 +505,8 @@ fn buy_now_work() {
 		assert_eq!(Balances::free_balance(ALICE), 99600);
 		// initial balance is 500 - sold 2 x 200 = 900
 		// loyalty fee is 1% for both sales is 8
-		// 900 - 8 = 892
-		assert_eq!(Balances::free_balance(BOB), 892);
+		// 900 - 8 + 4 for deposit minting = 888
+		assert_eq!(Balances::free_balance(BOB), 888);
 
 		// event was triggered
 		let event = mock::Event::AuctionModule(crate::Event::BuyNowFinalised(1, ALICE, 200));
@@ -759,8 +767,8 @@ fn on_finalize_should_work() {
 		assert_eq!(NFTModule::<Runtime>::get_assets_by_owner(ALICE), [0]);
 		// check balances were transferred
 		assert_eq!(Balances::free_balance(ALICE), 99900);
-		// BOB only receive 597 - 1 (1% of 100 as loyalty fee) = 596
-		assert_eq!(Balances::free_balance(BOB), 596);
+		// BOB only receive 596 - 1 (1% of 100 as loyalty fee) + 4 minting fee = 591
+		assert_eq!(Balances::free_balance(BOB), 591);
 		// asset is not longer in auction
 		assert_eq!(AuctionModule::items_in_auction(ItemId::NFT(0)), None);
 		// event was triggered

--- a/pallets/nft/src/mock.rs
+++ b/pallets/nft/src/mock.rs
@@ -1,17 +1,20 @@
 #![cfg(test)]
 
-use super::*;
-
-use crate as nft;
-use auction_manager::{Auction, AuctionInfo, AuctionType, ListingLevel};
+use codec::{Decode, Encode};
 use frame_support::traits::Nothing;
 use frame_support::{construct_runtime, parameter_types};
 use frame_system::{EnsureRoot, EnsureSignedBy};
 use orml_traits::parameter_type_with_key;
-use primitives::{Amount, CurrencyId, FungibleTokenId, ItemId};
 use sp_core::H256;
 use sp_runtime::testing::Header;
 use sp_runtime::traits::IdentityLookup;
+
+use auction_manager::{Auction, AuctionInfo, AuctionType, ListingLevel};
+use primitives::{Amount, CurrencyId, FungibleTokenId, ItemId};
+
+use crate as nft;
+
+use super::*;
 
 parameter_types! {
 	pub const BlockHashCount: u32 = 256;
@@ -157,8 +160,7 @@ impl CheckAuctionItemHandler for MockAuctionManager {
 }
 
 parameter_types! {
-	pub CreateClassDeposit: Balance = 2;
-	pub CreateAssetDeposit: Balance = 1;
+	pub MetadataDataDepositPerByte: Balance = 1;
 	pub NftPalletId: PalletId = PalletId(*b"bit/bNFT");
 	pub MaxBatchTransfer: u32 = 3;
 	pub MaxBatchMinting: u32 = 10;
@@ -210,8 +212,6 @@ impl pallet_scheduler::Config for Runtime {
 
 impl Config for Runtime {
 	type Event = Event;
-	type CreateClassDeposit = CreateClassDeposit;
-	type CreateAssetDeposit = CreateAssetDeposit;
 	type Currency = Balances;
 	type PalletId = NftPalletId;
 	type AuctionHandler = MockAuctionManager;
@@ -222,6 +222,7 @@ impl Config for Runtime {
 	type MultiCurrency = Currencies;
 	type MiningResourceId = MiningCurrencyId;
 	type PromotionIncentive = PromotionIncentive;
+	type DataDepositPerByte = MetadataDataDepositPerByte;
 }
 
 parameter_types! {

--- a/runtime/metaverse/src/lib.rs
+++ b/runtime/metaverse/src/lib.rs
@@ -426,8 +426,7 @@ impl currencies::Config for Runtime {
 }
 
 parameter_types! {
-	pub CreateClassDeposit: Balance = 500 * MILLICENTS;
-	pub CreateAssetDeposit: Balance = 100 * MILLICENTS;
+	pub MetadataDepositPerByte: Balance = 1 * CENTS;
 	pub MaxBatchTransfer: u32 = 100;
 	pub MaxBatchMinting: u32 = 1000;
 	pub MaxNftMetadata: u32 = 1024;
@@ -436,8 +435,6 @@ parameter_types! {
 
 impl nft::Config for Runtime {
 	type Event = Event;
-	type CreateClassDeposit = CreateClassDeposit;
-	type CreateAssetDeposit = CreateAssetDeposit;
 	type Currency = Balances;
 	type MultiCurrency = Currencies;
 	type WeightInfo = weights::module_nft::WeightInfo<Runtime>;
@@ -448,6 +445,7 @@ impl nft::Config for Runtime {
 	type MaxMetadata = MaxNftMetadata;
 	type MiningResourceId = MiningResourceCurrencyId;
 	type PromotionIncentive = PromotionIncentive;
+	type DataDepositPerByte = MetadataDepositPerByte;
 }
 
 parameter_types! {

--- a/runtime/pioneer/src/lib.rs
+++ b/runtime/pioneer/src/lib.rs
@@ -880,8 +880,7 @@ impl mining::Config for Runtime {
 }
 
 parameter_types! {
-	pub CreateClassDeposit: Balance = 500 * MILLICENTS;
-	pub CreateAssetDeposit: Balance = 100 * MILLICENTS;
+	pub MetadataDepositPerByte: Balance = 1 * CENTS;
 	pub MaxBatchTransfer: u32 = 100;
 	pub MaxBatchMinting: u32 = 1000;
 	pub MaxNftMetadata: u32 = 1024;
@@ -889,19 +888,18 @@ parameter_types! {
 }
 
 //impl nft::Config for Runtime {
-//    type Event = Event;
-//    type CreateClassDeposit = CreateClassDeposit;
-//    type CreateAssetDeposit = CreateAssetDeposit;
-//    type Currency = Balances;
-//    type MultiCurrency = Currencies;
-//    type WeightInfo = weights::module_nft::WeightInfo<Runtime>;
-//    type PalletId = NftPalletId;
-//    type AuctionHandler = Auction;
-//    type MaxBatchTransfer = MaxBatchTransfer;
-//    type MaxBatchMinting = MaxBatchMinting;
-//    type MaxMetadata = MaxNftMetadata;
-//    type MiningResourceId = MiningResourceCurrencyId;
-//    type PromotionIncentive = PromotionIncentive;
+//	type Event = Event;
+//	type Currency = Balances;
+//	type MultiCurrency = Currencies;
+//	type WeightInfo = weights::module_nft::WeightInfo<Runtime>;
+//	type PalletId = NftPalletId;
+//	type AuctionHandler = Auction;
+//	type MaxBatchTransfer = MaxBatchTransfer;
+//	type MaxBatchMinting = MaxBatchMinting;
+//	type MaxMetadata = MaxNftMetadata;
+//	type MiningResourceId = MiningResourceCurrencyId;
+//	type PromotionIncentive = PromotionIncentive;
+//	type DataDepositPerByte = MetadataDepositPerByte;
 //}
 //
 //parameter_types! {


### PR DESCRIPTION
- Include attributes to class and asset data instead of CID.
- Calculate deposit fee depending on attributes length.
- Upgraded unit test to test if minting fee deposits correctly based on attribute length.