### PR TITLE
Include listing fee under metaverse info struct, minimize separate storage used

### DIFF
--- a/pallets/auction/src/lib.rs
+++ b/pallets/auction/src/lib.rs
@@ -540,7 +540,7 @@ pub mod pallet {
 			let mut listing_fee: Perbill = Perbill::from_percent(0u32);
 			match listing_level {
 				ListingLevel::Local(metaverse_id) => {
-					listing_fee = T::MetaverseInfoSource::get_metaverse_marketplace_listing_fee(metaverse_id);
+					listing_fee = T::MetaverseInfoSource::get_metaverse_marketplace_listing_fee(metaverse_id)?;
 				}
 				_ => {}
 			}
@@ -595,7 +595,7 @@ pub mod pallet {
 			let mut listing_fee: Perbill = Perbill::from_percent(0u32);
 			match listing_level {
 				ListingLevel::Local(metaverse_id) => {
-					listing_fee = T::MetaverseInfoSource::get_metaverse_marketplace_listing_fee(metaverse_id);
+					listing_fee = T::MetaverseInfoSource::get_metaverse_marketplace_listing_fee(metaverse_id)?;
 				}
 				_ => {}
 			}

--- a/pallets/auction/src/mock.rs
+++ b/pallets/auction/src/mock.rs
@@ -226,8 +226,8 @@ impl MetaverseTrait<AccountId> for MetaverseInfoSource {
 		16u32
 	}
 
-	fn get_metaverse_marketplace_listing_fee(metaverse_id: MetaverseId) -> Perbill {
-		Perbill::from_percent(1u32)
+	fn get_metaverse_marketplace_listing_fee(metaverse_id: MetaverseId) -> Result<Perbill, DispatchError> {
+		Ok(Perbill::from_percent(1u32))
 	}
 
 	fn get_metaverse_treasury(metaverse_id: MetaverseId) -> AccountId {

--- a/pallets/continuum/src/mock.rs
+++ b/pallets/continuum/src/mock.rs
@@ -216,8 +216,8 @@ impl MetaverseTrait<AccountId> for MetaverseInfoSource {
 		16u32
 	}
 
-	fn get_metaverse_marketplace_listing_fee(metaverse_id: MetaverseId) -> Perbill {
-		Perbill::from_percent(1u32)
+	fn get_metaverse_marketplace_listing_fee(metaverse_id: MetaverseId) -> Result<Perbill, DispatchError> {
+		Ok(Perbill::from_percent(1u32))
 	}
 
 	fn get_metaverse_treasury(metaverse_id: MetaverseId) -> AccountId {

--- a/pallets/estate/src/mock.rs
+++ b/pallets/estate/src/mock.rs
@@ -155,8 +155,8 @@ impl MetaverseTrait<AccountId> for MetaverseInfoSource {
 		16u32
 	}
 
-	fn get_metaverse_marketplace_listing_fee(metaverse_id: MetaverseId) -> Perbill {
-		Perbill::from_percent(1u32)
+	fn get_metaverse_marketplace_listing_fee(metaverse_id: MetaverseId) -> Result<Perbill, DispatchError> {
+		Ok(Perbill::from_percent(1u32))
 	}
 
 	fn get_metaverse_treasury(metaverse_id: MetaverseId) -> AccountId {

--- a/pallets/governance/src/mock.rs
+++ b/pallets/governance/src/mock.rs
@@ -168,8 +168,8 @@ impl MetaverseTrait<AccountId> for MetaverseInfo {
 		16u32
 	}
 
-	fn get_metaverse_marketplace_listing_fee(metaverse_id: MetaverseId) -> Perbill {
-		Perbill::from_percent(1u32)
+	fn get_metaverse_marketplace_listing_fee(metaverse_id: MetaverseId) -> Result<Perbill, DispatchError> {
+		Ok(Perbill::from_percent(1u32))
 	}
 
 	fn get_metaverse_treasury(metaverse_id: MetaverseId) -> AccountId {

--- a/pallets/metaverse/src/benchmarking.rs
+++ b/pallets/metaverse/src/benchmarking.rs
@@ -20,19 +20,21 @@
 
 #![cfg(feature = "runtime-benchmarks")]
 
-use super::*;
+use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite, whitelisted_caller};
+use frame_support::traits::{Currency, Get};
+use frame_system::RawOrigin;
+use sp_runtime::traits::{AccountIdConversion, StaticLookup, UniqueSaturatedInto};
+use sp_runtime::Perbill;
 use sp_std::prelude::*;
 use sp_std::vec;
+
+use primitives::Balance;
 
 #[allow(unused)]
 pub use crate::Pallet as MetaverseModule;
 use crate::*;
-use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite, whitelisted_caller};
-use frame_support::traits::{Currency, Get};
-use frame_system::RawOrigin;
-use primitives::Balance;
-use sp_runtime::traits::{AccountIdConversion, StaticLookup, UniqueSaturatedInto};
-use sp_runtime::Perbill;
+
+use super::*;
 
 pub type AccountId = u128;
 

--- a/pallets/metaverse/src/tests.rs
+++ b/pallets/metaverse/src/tests.rs
@@ -37,6 +37,7 @@ fn create_metaverse_should_work() {
 				metadata: vec![1],
 				currency_id: FungibleTokenId::NativeToken(0),
 				is_frozen: false,
+				listing_fee: Perbill::from_percent(0u32)
 			})
 		);
 		let event = Event::Metaverse(crate::Event::NewMetaverseCreated(METAVERSE_ID, ALICE));
@@ -351,7 +352,7 @@ fn update_metaverse_listing_fee_should_work() {
 		));
 		assert_eq!(
 			MetaverseModule::get_metaverse_marketplace_listing_fee(METAVERSE_ID),
-			Perbill::from_percent(10u32)
+			Ok(Perbill::from_percent(10u32))
 		);
 	})
 }

--- a/pallets/tokenization/src/mock.rs
+++ b/pallets/tokenization/src/mock.rs
@@ -149,8 +149,8 @@ impl MetaverseTrait<AccountId> for MetaverseInfoSource {
 		16u32
 	}
 
-	fn get_metaverse_marketplace_listing_fee(metaverse_id: MetaverseId) -> Perbill {
-		Perbill::from_percent(1u32)
+	fn get_metaverse_marketplace_listing_fee(metaverse_id: MetaverseId) -> Result<Perbill, DispatchError> {
+		Ok(Perbill::from_percent(1u32))
 	}
 
 	fn get_metaverse_treasury(metaverse_id: MetaverseId) -> AccountId {

--- a/traits/core-primitives/src/lib.rs
+++ b/traits/core-primitives/src/lib.rs
@@ -139,6 +139,8 @@ pub struct MetaverseInfo<AccountId> {
 	pub currency_id: FungibleTokenId,
 	/// Whether the metaverse can be transferred or not.
 	pub is_frozen: bool,
+	/// Metaverse listing fee
+	pub listing_fee: Perbill,
 }
 
 #[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo)]
@@ -167,7 +169,7 @@ pub trait MetaverseTrait<AccountId> {
 	/// Get the estate class for a specific metaverse
 	fn get_metaverse_estate_class(metaverse_id: MetaverseId) -> ClassId;
 	/// Get metaverse marketplace listing fee
-	fn get_metaverse_marketplace_listing_fee(metaverse_id: MetaverseId) -> Perbill;
+	fn get_metaverse_marketplace_listing_fee(metaverse_id: MetaverseId) -> Result<Perbill, DispatchError>;
 	/// Get metaverse treasury
 	fn get_metaverse_treasury(metaverse_id: MetaverseId) -> AccountId;
 }

--- a/traits/core-primitives/src/lib.rs
+++ b/traits/core-primitives/src/lib.rs
@@ -144,6 +144,18 @@ pub struct MetaverseInfo<AccountId> {
 }
 
 #[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo)]
+pub struct MetaverseInfoV1<AccountId> {
+	/// The owner of this metaverse
+	pub owner: AccountId,
+	/// The metadata of this metaverse
+	pub metadata: MetaverseMetadata,
+	/// The currency use in this metaverse
+	pub currency_id: FungibleTokenId,
+	/// Whether the metaverse can be transferred or not.
+	pub is_frozen: bool,
+}
+
+#[derive(Encode, Decode, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo)]
 pub struct MetaverseFund<AccountId, Balance> {
 	/// The fund account of this metaverse
 	pub vault: AccountId,


### PR DESCRIPTION
- [x] Restructure listing fee to include inside Metaverse struct
- [x] Update existing trait to support querying listing fee from struct
- [x]  Unit test to ensure existing logic still working.
- [x] Storage migration to update new listing fee struct 