### PR TITLE
Feature/self authorized for estate of metaverse

### DIFF
--- a/pallets/auction/src/lib.rs
+++ b/pallets/auction/src/lib.rs
@@ -996,7 +996,8 @@ pub mod pallet {
 						ListingLevel::Local(metaverse_id) => {
 							ensure!(
 								MetaverseCollection::<T>::contains_key(metaverse_id, class_id)
-									|| T::MetaverseInfoSource::check_ownership(&recipient, &metaverse_id),
+									|| T::MetaverseInfoSource::check_ownership(&recipient, &metaverse_id)
+									|| T::MetaverseInfoSource::check_if_metaverse_estate(metaverse_id, &class_id)?,
 								Error::<T>::NoPermissionToCreateAuction
 							);
 						}

--- a/pallets/auction/src/mock.rs
+++ b/pallets/auction/src/mock.rs
@@ -1,4 +1,5 @@
 #![cfg(test)]
+
 use frame_support::traits::{EqualPrivilegeOnly, Nothing};
 use frame_support::{construct_runtime, pallet_prelude::Hooks, parameter_types, PalletId};
 use frame_system::EnsureRoot;
@@ -261,6 +262,16 @@ impl MetaverseTrait<AccountId> for MetaverseInfoSource {
 
 	fn get_network_treasury() -> AccountId {
 		GENERAL_METAVERSE_FUND
+	}
+
+	fn check_if_metaverse_estate(
+		metaverse_id: primitives::MetaverseId,
+		class_id: &ClassId,
+	) -> Result<bool, DispatchError> {
+		if class_id == &15u32 || class_id == &16u32 {
+			return Ok(true);
+		}
+		return Ok(false);
 	}
 }
 

--- a/pallets/continuum/src/mock.rs
+++ b/pallets/continuum/src/mock.rs
@@ -235,6 +235,16 @@ impl MetaverseTrait<AccountId> for MetaverseInfoSource {
 	fn get_network_treasury() -> AccountId {
 		GENERAL_METAVERSE_FUND
 	}
+
+	fn check_if_metaverse_estate(
+		metaverse_id: primitives::MetaverseId,
+		class_id: &ClassId,
+	) -> Result<bool, DispatchError> {
+		if class_id == &15u32 || class_id == &16u32 {
+			return Ok(true);
+		}
+		return Ok(false);
+	}
 }
 
 impl Config for Runtime {

--- a/pallets/currencies/src/mock.rs
+++ b/pallets/currencies/src/mock.rs
@@ -128,11 +128,11 @@ impl MetaverseTrait<AccountId> for MetaverseInfoSource {
 		None
 	}
 
-	fn get_metaverse_land_class(metaverse_id: MetaverseId) ->  Result<ClassId, DispatchError> {
+	fn get_metaverse_land_class(metaverse_id: MetaverseId) -> Result<ClassId, DispatchError> {
 		Ok(15u32)
 	}
 
-	fn get_metaverse_estate_class(metaverse_id: MetaverseId) ->  Result<ClassId, DispatchError> {
+	fn get_metaverse_estate_class(metaverse_id: MetaverseId) -> Result<ClassId, DispatchError> {
 		Ok(16u32)
 	}
 
@@ -146,6 +146,16 @@ impl MetaverseTrait<AccountId> for MetaverseInfoSource {
 
 	fn get_network_treasury() -> AccountId {
 		GENERAL_METAVERSE_FUND
+	}
+
+	fn check_if_metaverse_estate(
+		metaverse_id: primitives::MetaverseId,
+		class_id: &ClassId,
+	) -> Result<bool, DispatchError> {
+		if class_id == &15u32 || class_id == &16u32 {
+			return Ok(true);
+		}
+		return Ok(false);
 	}
 }
 

--- a/pallets/estate/src/mock.rs
+++ b/pallets/estate/src/mock.rs
@@ -175,6 +175,16 @@ impl MetaverseTrait<AccountId> for MetaverseInfoSource {
 	fn get_network_treasury() -> AccountId {
 		GENERAL_METAVERSE_FUND
 	}
+
+	fn check_if_metaverse_estate(
+		metaverse_id: primitives::MetaverseId,
+		class_id: &ClassId,
+	) -> Result<bool, DispatchError> {
+		if class_id == &METAVERSE_LAND_CLASS || class_id == &METAVERSE_ESTATE_CLASS {
+			return Ok(true);
+		}
+		return Ok(false);
+	}
 }
 
 pub struct MockAuctionManager;

--- a/pallets/estate/src/tests.rs
+++ b/pallets/estate/src/tests.rs
@@ -1408,7 +1408,7 @@ fn deploy_undeployed_land_block_should_fail_if_not_found() {
 			EstateModule::deploy_land_block(
 				Origin::signed(ALICE),
 				undeployed_land_block_id,
-				METAVERSE_ID,
+				ALICE_METAVERSE_ID,
 				LANDBLOCK_COORDINATE,
 				vec![COORDINATE_IN_1]
 			),
@@ -1467,7 +1467,7 @@ fn deploy_undeployed_land_block_should_fail_if_freezed() {
 			EstateModule::deploy_land_block(
 				Origin::signed(BOB),
 				undeployed_land_block_id,
-				METAVERSE_ID,
+				BOB_METAVERSE_ID,
 				LANDBLOCK_COORDINATE,
 				vec![COORDINATE_IN_1]
 			),
@@ -1552,7 +1552,7 @@ fn deploy_undeployed_land_block_should_work() {
 		assert_ok!(EstateModule::deploy_land_block(
 			Origin::signed(BOB),
 			undeployed_land_block_id,
-			METAVERSE_ID,
+			BOB_METAVERSE_ID,
 			LANDBLOCK_COORDINATE,
 			vec![COORDINATE_IN_1, COORDINATE_IN_2]
 		));
@@ -1561,7 +1561,7 @@ fn deploy_undeployed_land_block_should_work() {
 			last_event(),
 			Event::Estate(crate::Event::LandBlockDeployed(
 				BOB,
-				METAVERSE_ID,
+				BOB_METAVERSE_ID,
 				undeployed_land_block_id,
 				vec![COORDINATE_IN_1, COORDINATE_IN_2],
 			))
@@ -2089,19 +2089,19 @@ fn issue_land_block_and_create_estate_should_work() {
 		assert_ok!(EstateModule::deploy_land_block(
 			Origin::signed(BOB),
 			0,
-			METAVERSE_ID,
+			BOB_METAVERSE_ID,
 			LANDBLOCK_COORDINATE,
 			vec![COORDINATE_IN_1, COORDINATE_IN_2]
 		));
 		assert_eq!(Balances::free_balance(BOB), 99999);
 
 		assert_eq!(
-			EstateModule::get_land_units(METAVERSE_ID, COORDINATE_IN_1),
+			EstateModule::get_land_units(BOB_METAVERSE_ID, COORDINATE_IN_1),
 			Some(OwnerId::Token(METAVERSE_LAND_CLASS, 2))
 		);
 
 		assert_eq!(
-			EstateModule::get_land_units(METAVERSE_ID, COORDINATE_IN_2),
+			EstateModule::get_land_units(BOB_METAVERSE_ID, COORDINATE_IN_2),
 			Some(OwnerId::Token(METAVERSE_LAND_CLASS, 2))
 		);
 	});

--- a/pallets/governance/src/mock.rs
+++ b/pallets/governance/src/mock.rs
@@ -6,12 +6,7 @@ use frame_support::traits::{EqualPrivilegeOnly, Nothing};
 use frame_support::{construct_runtime, ord_parameter_types, parameter_types};
 use frame_support::{pallet_prelude::Hooks, weights::Weight, PalletId};
 use frame_system::{EnsureRoot, EnsureSignedBy};
-use metaverse_primitive::{
-	Attributes, CollectionType, MetaverseInfo as MetaversePrimitiveInfo, MetaverseLandTrait, MetaverseMetadata,
-	MetaverseTrait, NFTTrait, NftClassData, NftMetadata, TokenType,
-};
 use orml_traits::parameter_type_with_key;
-use primitives::{Amount, ClassId, FungibleTokenId, GroupCollectionId, TokenId};
 use scale_info::TypeInfo;
 use sp_core::H256;
 use sp_runtime::{
@@ -20,6 +15,12 @@ use sp_runtime::{
 	Perbill,
 };
 use sp_std::collections::btree_map::BTreeMap;
+
+use metaverse_primitive::{
+	Attributes, CollectionType, MetaverseInfo as MetaversePrimitiveInfo, MetaverseLandTrait, MetaverseMetadata,
+	MetaverseTrait, NFTTrait, NftClassData, NftMetadata, TokenType,
+};
+use primitives::{Amount, ClassId, FungibleTokenId, GroupCollectionId, TokenId};
 
 use crate as governance;
 
@@ -178,6 +179,16 @@ impl MetaverseTrait<AccountId> for MetaverseInfo {
 
 	fn get_network_treasury() -> AccountId {
 		GENERAL_METAVERSE_FUND
+	}
+
+	fn check_if_metaverse_estate(
+		metaverse_id: primitives::MetaverseId,
+		class_id: &ClassId,
+	) -> Result<bool, DispatchError> {
+		if class_id == &15u32 || class_id == &16u32 {
+			return Ok(true);
+		}
+		return Ok(false);
 	}
 }
 

--- a/pallets/metaverse/src/lib.rs
+++ b/pallets/metaverse/src/lib.rs
@@ -840,11 +840,17 @@ impl<T: Config> MetaverseTrait<T::AccountId> for Pallet<T> {
 	}
 
 	fn get_metaverse_treasury(metaverse_id: MetaverseId) -> T::AccountId {
-		return T::MetaverseTreasury::get().into_account();
+		return T::MetaverseTreasury::get().into_sub_account(metaverse_id);
 	}
 
 	fn get_network_treasury() -> T::AccountId {
 		return T::MetaverseTreasury::get().into_account();
+	}
+
+	fn check_if_metaverse_estate(metaverse_id: MetaverseId, class_id: &ClassId) -> Result<bool, DispatchError> {
+		let metaverse_info = Self::get_metaverse(metaverse_id).ok_or(Error::<T>::MetaverseInfoNotFound)?;
+
+		Ok(class_id == &metaverse_info.land_class_id || class_id == &metaverse_info.estate_class_id)
 	}
 }
 

--- a/pallets/tokenization/src/mock.rs
+++ b/pallets/tokenization/src/mock.rs
@@ -162,6 +162,16 @@ impl MetaverseTrait<AccountId> for MetaverseInfoSource {
 	fn get_network_treasury() -> AccountId {
 		GENERAL_METAVERSE_FUND
 	}
+
+	fn check_if_metaverse_estate(
+		metaverse_id: primitives::MetaverseId,
+		class_id: &ClassId,
+	) -> Result<bool, DispatchError> {
+		if class_id == &15u32 || class_id == &16u32 {
+			return Ok(true);
+		}
+		return Ok(false);
+	}
 }
 
 pub struct DEXManager {}

--- a/traits/core-primitives/src/lib.rs
+++ b/traits/core-primitives/src/lib.rs
@@ -192,6 +192,8 @@ pub trait MetaverseTrait<AccountId> {
 	fn get_metaverse_treasury(metaverse_id: MetaverseId) -> AccountId;
 	/// Get network treasury
 	fn get_network_treasury() -> AccountId;
+	/// Check if nft is estate or land belongs to metaverse
+	fn check_if_metaverse_estate(metaverse_id: MetaverseId, class_id: &ClassId) -> Result<bool, DispatchError>;
 }
 
 pub trait MetaverseLandTrait<AccountId> {


### PR DESCRIPTION
This feature allows estate or land units to trade on its metaverse marketplace without authorisation from the metaverse owner. It also improves the metaverse treasury account generate to a specific metaverse.

- [x] Extended check ownership on metaverse trait for cross-pallet to interact.
- [x] Trait implementation for checking if lands belong to metaverse on pallet metaverse
- [x] Updated existing implementation to ensure no conflict
- [x] Updated metaverse fund generation
- [x] Updated auction logic when a new listing is land.
- [x] Updated unit tests to ensure new implementation all working as expected