### PR TITLE
Feature/continuum map improvement - New optimized and improved continuum map logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6397,6 +6397,7 @@ dependencies = [
  "orml-tokens 0.4.1-dev (git+https://github.com/bit-country/open-runtime-module-library?branch=v-9.17)",
  "orml-traits 0.4.1-dev (git+https://github.com/bit-country/open-runtime-module-library?branch=v-9.17)",
  "pallet-balances 4.0.0-dev (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.17)",
+ "pallet-metaverse",
  "pallet-nft",
  "parity-scale-codec 2.3.1",
  "scale-info 1.0.0",

--- a/pallets/auction/src/lib.rs
+++ b/pallets/auction/src/lib.rs
@@ -314,6 +314,14 @@ pub mod pallet {
 		pub fn bid(origin: OriginFor<T>, id: AuctionId, value: BalanceOf<T>) -> DispatchResultWithPostInfo {
 			let from = ensure_signed(origin)?;
 
+			let auction_item: AuctionItem<T::AccountId, T::BlockNumber, BalanceOf<T>> =
+				Self::get_auction_item(id.clone()).ok_or(Error::<T>::AuctionDoesNotExist)?;
+
+			ensure!(
+				!auction_item.item_id.is_map_spot(),
+				Error::<T>::AuctionTypeIsNotSupported
+			);
+
 			Self::auction_bid_handler(from, id, value)?;
 
 			Ok(().into())
@@ -333,6 +341,14 @@ pub mod pallet {
 		#[transactional]
 		pub fn buy_now(origin: OriginFor<T>, auction_id: AuctionId, value: BalanceOf<T>) -> DispatchResult {
 			let from = ensure_signed(origin)?;
+
+			let auction_item: AuctionItem<T::AccountId, T::BlockNumber, BalanceOf<T>> =
+				Self::get_auction_item(auction_id.clone()).ok_or(Error::<T>::AuctionDoesNotExist)?;
+
+			ensure!(
+				!auction_item.item_id.is_map_spot(),
+				Error::<T>::AuctionTypeIsNotSupported
+			);
 
 			Self::buy_now_handler(from, auction_id, value)?;
 

--- a/pallets/auction/src/lib.rs
+++ b/pallets/auction/src/lib.rs
@@ -39,7 +39,7 @@ use auction_manager::{Auction, AuctionHandler, AuctionInfo, AuctionItem, Auction
 use core_primitives::UndeployedLandBlocksTrait;
 pub use pallet::*;
 use pallet_nft::Pallet as NFTModule;
-use primitives::{continuum::Continuum, estate::Estate, AuctionId, ItemId};
+use primitives::{continuum::MapTrait, estate::Estate, AuctionId, ItemId};
 pub use weights::WeightInfo;
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -147,7 +147,7 @@ pub mod pallet {
 			Balance = Balance,
 		>;
 		/// Continuum protocol handler for Continuum Spot Auction
-		type ContinuumHandler: Continuum<Self::AccountId>;
+		type ContinuumHandler: MapTrait<Self::AccountId>;
 
 		/// Metaverse info trait for getting information from metaverse
 		type MetaverseInfoSource: MetaverseTrait<Self::AccountId>;

--- a/pallets/auction/src/mock.rs
+++ b/pallets/auction/src/mock.rs
@@ -11,7 +11,8 @@ use sp_runtime::{testing::Header, traits::IdentityLookup, Perbill};
 use auction_manager::{CheckAuctionItemHandler, ListingLevel};
 use core_primitives::{MetaverseInfo, MetaverseMetadata, MetaverseTrait, NftAssetData, NftClassData};
 use primitives::{
-	continuum::Continuum, estate::Estate, Amount, AuctionId, ClassId, EstateId, FungibleTokenId, UndeployedLandBlockId,
+	continuum::MapTrait, estate::Estate, Amount, AuctionId, ClassId, EstateId, FungibleTokenId, MapSpotId,
+	UndeployedLandBlockId,
 };
 
 use crate as auction;
@@ -91,8 +92,8 @@ impl pallet_balances::Config for Runtime {
 
 pub struct Continuumm;
 
-impl Continuum<u128> for Continuumm {
-	fn transfer_spot(_spot_id: u64, _from: &AccountId, _to: &(AccountId, u64)) -> Result<u64, DispatchError> {
+impl MapTrait<u128> for Continuumm {
+	fn transfer_spot(_spot_id: u64, _from: &AccountId, _to: &AccountId) -> Result<u64, DispatchError> {
 		Ok(1)
 	}
 }

--- a/pallets/auction/src/mock.rs
+++ b/pallets/auction/src/mock.rs
@@ -93,8 +93,12 @@ impl pallet_balances::Config for Runtime {
 pub struct Continuumm;
 
 impl MapTrait<u128> for Continuumm {
-	fn transfer_spot(_spot_id: u64, _from: AccountId, _to: (AccountId, MetaverseId)) -> Result<u64, DispatchError> {
-		Ok(1)
+	fn transfer_spot(
+		_spot_id: MapSpotId,
+		_from: AccountId,
+		_to: (AccountId, MetaverseId),
+	) -> Result<MapSpotId, DispatchError> {
+		Ok((0, 0))
 	}
 }
 
@@ -441,7 +445,15 @@ impl Auction<AccountId, BlockNumber> for MockAuctionManager {
 		None
 	}
 
+	fn auction_item(id: AuctionId) -> Option<AuctionItem<AccountId, BlockNumber, Self::Balance>> {
+		None
+	}
+
 	fn update_auction(_id: u64, _info: AuctionInfo<u128, Self::Balance, u64>) -> DispatchResult {
+		Ok(())
+	}
+
+	fn update_auction_item(id: AuctionId, item_id: ItemId<Self::Balance>) -> frame_support::dispatch::DispatchResult {
 		Ok(())
 	}
 
@@ -470,11 +482,18 @@ impl Auction<AccountId, BlockNumber> for MockAuctionManager {
 	fn remove_auction(_id: u64, _item_id: ItemId<Balance>) {}
 
 	fn auction_bid_handler(
-		_now: u64,
-		_id: u64,
-		_new_bid: (u128, Self::Balance),
-		_last_bid: Option<(u128, Self::Balance)>,
-	) -> DispatchResult {
+		from: AccountId,
+		id: AuctionId,
+		value: Self::Balance,
+	) -> frame_support::dispatch::DispatchResult {
+		Ok(())
+	}
+
+	fn buy_now_handler(
+		from: AccountId,
+		auction_id: AuctionId,
+		value: Self::Balance,
+	) -> frame_support::dispatch::DispatchResult {
 		Ok(())
 	}
 

--- a/pallets/auction/src/mock.rs
+++ b/pallets/auction/src/mock.rs
@@ -93,7 +93,7 @@ impl pallet_balances::Config for Runtime {
 pub struct Continuumm;
 
 impl MapTrait<u128> for Continuumm {
-	fn transfer_spot(_spot_id: u64, _from: &AccountId, _to: &AccountId) -> Result<u64, DispatchError> {
+	fn transfer_spot(_spot_id: u64, _from: AccountId, _to: (AccountId, MetaverseId)) -> Result<u64, DispatchError> {
 		Ok(1)
 	}
 }

--- a/pallets/continuum/Cargo.toml
+++ b/pallets/continuum/Cargo.toml
@@ -34,23 +34,13 @@ orml-currencies = { git = "https://github.com/bit-country/open-runtime-module-li
 orml-tokens = { git = "https://github.com/bit-country/open-runtime-module-library", branch = "v-9.17", default-features = false }
 orml-nft = { git = "https://github.com/bit-country/open-runtime-module-library", branch = "v-9.17", default-features = false }
 
-[dependencies.pallet_nft]
-default-features = false
-package = 'pallet-nft'
-path = '../nft'
-version = '2.0.0-rc6'
+# Other pallets
 
-[dependencies.auction-manager]
-default-features = false
-package = 'auction-manager'
-path = '../../traits/auction-manager'
-version = '2.0.0-rc6'
+pallet-nft = { default-features = false, package = 'pallet-nft', path = '../nft' }
+pallet-metaverse = { default-features = false, package = 'pallet-metaverse', path = '../metaverse' }
+auction-manager = { default-features = false, package = 'auction-manager', path = '../../traits/auction-manager' }
+core-primitives = { path = "../../traits/core-primitives", default-features = false }
 
-[dependencies.core-primitives]
-default-features = false
-package = 'core-primitives'
-path = '../../traits/core-primitives'
-version = '2.0.0-rc6'
 
 [features]
 default = ['std']
@@ -65,7 +55,7 @@ std = [
     'sp-std/std',
     'orml-traits/std',
     'orml-tokens/std',
-    'pallet_nft/std',
+    'pallet-nft/std',
     'auction-manager/std',
     'primitives/std',
     'sp-arithmetic/std',

--- a/pallets/continuum/src/lib.rs
+++ b/pallets/continuum/src/lib.rs
@@ -412,7 +412,7 @@ pub mod pallet {
 			auction_id: AuctionId,
 			value: BalanceOf<T>,
 			metaverse_id: MetaverseId,
-		) -> DispatchResultWithPostInfo {
+		) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 			ensure!(
 				T::MetaverseInfoSource::check_ownership(&sender, &metaverse_id),

--- a/pallets/continuum/src/mock.rs
+++ b/pallets/continuum/src/mock.rs
@@ -23,9 +23,9 @@ use frame_system::EnsureSignedBy;
 use sp_core::H256;
 use sp_runtime::{testing::Header, traits::IdentityLookup, Perbill};
 
-use auction_manager::{Auction, AuctionInfo, CheckAuctionItemHandler, ListingLevel};
+use auction_manager::{Auction, AuctionInfo, AuctionItem, CheckAuctionItemHandler, ListingLevel};
 use core_primitives::{MetaverseInfo, MetaverseMetadata, MetaverseTrait};
-use primitives::{ClassId, FungibleTokenId};
+use primitives::{AuctionId, ClassId, FungibleTokenId};
 
 use crate as continuum;
 
@@ -111,7 +111,15 @@ impl Auction<AccountId, BlockNumber> for MockAuctionManager {
 		None
 	}
 
+	fn auction_item(id: AuctionId) -> Option<AuctionItem<AccountId, BlockNumber, Self::Balance>> {
+		None
+	}
+
 	fn update_auction(_id: u64, _info: AuctionInfo<u128, Self::Balance, u64>) -> DispatchResult {
+		Ok(())
+	}
+
+	fn update_auction_item(id: AuctionId, item_id: ItemId<Self::Balance>) -> DispatchResult {
 		Ok(())
 	}
 
@@ -139,12 +147,11 @@ impl Auction<AccountId, BlockNumber> for MockAuctionManager {
 
 	fn remove_auction(_id: u64, _item_id: ItemId<Balance>) {}
 
-	fn auction_bid_handler(
-		_now: u64,
-		_id: u64,
-		_new_bid: (u128, Self::Balance),
-		_last_bid: Option<(u128, Self::Balance)>,
-	) -> DispatchResult {
+	fn auction_bid_handler(from: AccountId, id: AuctionId, value: Self::Balance) -> DispatchResult {
+		Ok(())
+	}
+
+	fn buy_now_handler(from: AccountId, auction_id: AuctionId, value: Self::Balance) -> DispatchResult {
 		Ok(())
 	}
 

--- a/pallets/continuum/src/mock.rs
+++ b/pallets/continuum/src/mock.rs
@@ -25,6 +25,7 @@ use sp_runtime::{testing::Header, traits::IdentityLookup, Perbill};
 
 use auction_manager::{Auction, AuctionInfo, AuctionItem, CheckAuctionItemHandler, ListingLevel};
 use core_primitives::{MetaverseInfo, MetaverseMetadata, MetaverseTrait};
+use primitives::FungibleTokenId::FungibleToken;
 use primitives::{AuctionId, ClassId, FungibleTokenId};
 
 use crate as continuum;
@@ -54,6 +55,8 @@ pub const CHARLIE_METAVERSE_ID: MetaverseId = 3;
 pub const ALICE_METAVERSE_FUND: AccountId = 100;
 pub const BOB_METAVERSE_FUND: AccountId = 101;
 pub const GENERAL_METAVERSE_FUND: AccountId = 102;
+
+pub const CONTINUUM_MAP_COORDINATE: MapSpotId = (0, 0);
 
 ord_parameter_types! {
 	pub const One: AccountId = ALICE;
@@ -107,15 +110,30 @@ pub struct MockAuctionManager;
 impl Auction<AccountId, BlockNumber> for MockAuctionManager {
 	type Balance = Balance;
 
-	fn auction_info(_id: u64) -> Option<AuctionInfo<u128, Self::Balance, u64>> {
+	fn auction_info(_id: AuctionId) -> Option<AuctionInfo<u128, Self::Balance, u64>> {
 		None
 	}
 
 	fn auction_item(id: AuctionId) -> Option<AuctionItem<AccountId, BlockNumber, Self::Balance>> {
-		None
+		if id == 1 {
+			let auction_item = AuctionItem {
+				item_id: ItemId::Spot(CONTINUUM_MAP_COORDINATE, 0),
+				recipient: ALICE_METAVERSE_FUND,
+				initial_amount: 100,
+				amount: 100,
+				start_time: 0,
+				end_time: 1,
+				auction_type: AuctionType::BuyNow,
+				listing_level: ListingLevel::Global,
+				currency_id: FungibleTokenId::NativeToken(0),
+				listing_fee: Perbill::from_percent(0u32),
+			};
+			return Some(auction_item);
+		}
+		return None;
 	}
 
-	fn update_auction(_id: u64, _info: AuctionInfo<u128, Self::Balance, u64>) -> DispatchResult {
+	fn update_auction(id: AuctionId, _info: AuctionInfo<u128, Self::Balance, u64>) -> DispatchResult {
 		Ok(())
 	}
 

--- a/pallets/continuum/src/tests.rs
+++ b/pallets/continuum/src/tests.rs
@@ -17,10 +17,12 @@
 
 #![cfg(test)]
 
-use super::*;
 use frame_support::{assert_noop, assert_ok};
+
 use mock::BlockNumber as MBlockNumber;
 use mock::{Event, *};
+
+use super::*;
 
 #[test]
 fn find_neighborhood_spot_should_work() {
@@ -84,11 +86,6 @@ fn try_vote_works_if_voter_is_neighbour() {
 
 		// Charlie buy neighbor slot using buy now option
 		assert_ok!(ContinuumModule::set_allow_buy_now(Origin::root(), true));
-		assert_ok!(ContinuumModule::buy_continuum_spot(
-			Origin::signed(CHARLIE),
-			(-1, 1),
-			CHARLIE_METAVERSE_ID
-		));
 		run_to_block(10);
 		// Start auction slot on continuum
 		let auction_slot = AuctionSlot {
@@ -240,11 +237,6 @@ fn rotate_session_should_work() {
 		assert_ok!(ContinuumModule::register_interest(bob, BOB_METAVERSE_ID, (0, 0)));
 
 		assert_ok!(ContinuumModule::set_allow_buy_now(Origin::root(), true));
-		assert_ok!(ContinuumModule::buy_continuum_spot(
-			Origin::signed(CHARLIE),
-			(-1, 1),
-			CHARLIE_METAVERSE_ID
-		));
 
 		run_to_block(10);
 
@@ -331,10 +323,6 @@ fn buy_now_continuum_should_fail_when_not_owner() {
 
 		// Enable Allow BuyNow
 		assert_ok!(ContinuumModule::set_allow_buy_now(root, true));
-		assert_noop!(
-			ContinuumModule::buy_continuum_spot(Origin::signed(ALICE), (0, 1), BOB_METAVERSE_ID),
-			Error::<Runtime>::NoPermission
-		);
 	})
 }
 
@@ -345,32 +333,11 @@ fn buy_now_continuum_should_work() {
 
 		// Enable Allow BuyNow
 		assert_ok!(ContinuumModule::set_allow_buy_now(root, true));
-		assert_ok!(ContinuumModule::buy_continuum_spot(
-			Origin::signed(ALICE),
-			(0, 1),
-			ALICE_METAVERSE_ID
-		));
-		assert_ok!(ContinuumModule::buy_continuum_spot(
-			Origin::signed(ALICE),
-			(0, 2),
-			ALICE_METAVERSE_ID
-		));
-
 		let continuum_spot_1 = ContinuumModule::get_continuum_spot(0);
 
 		assert_eq!(ContinuumModule::get_continuum_position((0, 1)), 0);
 		assert_eq!(ContinuumModule::get_continuum_position((0, 2)), 1);
 
 		assert_eq!(continuum_spot_1.metaverse_id, ALICE_METAVERSE_ID)
-	})
-}
-
-#[test]
-fn buy_now_continuum_should_fail_if_buy_now_setting_is_disabled() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_noop!(
-			ContinuumModule::buy_continuum_spot(Origin::signed(ALICE), (0, 1), ALICE_METAVERSE_ID),
-			Error::<Runtime>::ContinuumBuyNowIsDisabled
-		);
 	})
 }

--- a/pallets/continuum/src/tests.rs
+++ b/pallets/continuum/src/tests.rs
@@ -18,7 +18,9 @@
 #![cfg(test)]
 
 use frame_support::{assert_noop, assert_ok};
+use sp_runtime::traits::BadOrigin;
 
+use core_primitives::TokenType;
 use mock::BlockNumber as MBlockNumber;
 use mock::{Event, *};
 
@@ -47,282 +49,107 @@ fn find_neighborhood_spot_should_work() {
 }
 
 #[test]
-fn register_interest_should_work() {
+fn issue_continuum_spot_should_fail_when_no_root() {
 	ExtBuilder::default().build().execute_with(|| {
-		let origin = Origin::signed(ALICE);
+		let root = Origin::root();
+		// Enable Allow BuyNow
+		assert_ok!(ContinuumModule::set_allow_buy_now(root, true));
 
-		System::set_block_number(1);
-		assert_ok!(ContinuumModule::register_interest(origin, ALICE_METAVERSE_ID, (0, 0)));
-		assert_eq!(
-			last_event(),
-			Event::Continuum(crate::Event::NewExpressOfInterestAdded(ALICE, 0))
-		)
-	})
-}
-
-#[test]
-fn register_interest_should_not_work_for_non_owner() {
-	ExtBuilder::default().build().execute_with(|| {
-		let origin = Origin::signed(ALICE);
-		System::set_block_number(1);
 		assert_noop!(
-			ContinuumModule::register_interest(origin, BOB_METAVERSE_ID, (0, 0)),
-			Error::<Runtime>::NoPermission
+			ContinuumModule::issue_map_slot(Origin::signed(ALICE), CONTINUUM_MAP_COORDINATE, TokenType::Transferable),
+			BadOrigin
 		);
 	})
 }
 
 #[test]
-fn try_vote_works_if_voter_is_neighbour() {
+fn issue_continuum_spot_should_work() {
 	ExtBuilder::default().build().execute_with(|| {
-		let alice = Origin::signed(ALICE);
-		let bob = Origin::signed(BOB);
+		let root = Origin::root();
+		let treasury = <Runtime as Config>::ContinuumTreasury::get().into_account();
+		assert_ok!(ContinuumModule::issue_map_slot(
+			root,
+			CONTINUUM_MAP_COORDINATE,
+			TokenType::Transferable
+		));
 
-		System::set_block_number(1);
-
-		// Alice & Bob register for slot 0,0
-		assert_ok!(ContinuumModule::register_interest(alice, ALICE_METAVERSE_ID, (0, 0)));
-		assert_ok!(ContinuumModule::register_interest(bob, BOB_METAVERSE_ID, (0, 0)));
-
-		// Charlie buy neighbor slot using buy now option
-		assert_ok!(ContinuumModule::set_allow_buy_now(Origin::root(), true));
-		run_to_block(10);
-		// Start auction slot on continuum
-		let auction_slot = AuctionSlot {
-			spot_id: 0,
-			participants: vec![ALICE, BOB],
-			active_session_index: 1,
-			status: ContinuumAuctionSlotStatus::AcceptParticipates,
+		let map_spot = MapSpot {
+			metaverse_id: None,
+			owner: treasury,
+			slot_type: TokenType::Transferable,
 		};
 
-		let auction_slots: Vec<AuctionSlot<MBlockNumber, AccountId>> = vec![auction_slot];
-
-		let active_auctions: Option<Vec<AuctionSlot<MBlockNumber, AccountId>>> =
-			ContinuumModule::get_active_auction_slots(10);
-		match active_auctions {
-			Some(a) => {
-				// Verify EOI move to Auction Slots
-				assert_eq!(a[0].spot_id, auction_slots[0].spot_id);
-			}
-			_ => {
-				// Should fail test
-				assert_eq!(0, 1);
-			}
-		}
-
-		//Test starting GNP should work
-		run_to_block(20);
-		let gnp_started_auctions: Option<Vec<AuctionSlot<MBlockNumber, AccountId>>> =
-			ContinuumModule::get_active_gnp_slots(20);
-		match gnp_started_auctions {
-			Some(a) => {
-				// Verify Auction slots move to good neighborhood protocol Slots
-				assert_eq!(a[0].spot_id, a[0].spot_id);
-				assert_eq!(a[0].status, ContinuumAuctionSlotStatus::GNPStarted);
-
-				// Test start referendum should work
-				let status = ContinuumModule::referendum_status(0);
-				match status {
-					Ok(r) => {
-						assert_eq!(r.end, 30);
-					}
-					_ => {
-						assert_eq!(0, 1);
-					}
-				}
-			}
-			_ => {
-				// Should fail test
-				assert_eq!(0, 1);
-			}
-		}
-
-		// Try vote while referendum is active - charlie vote should be accepted
-		assert_ok!(ContinuumModule::try_vote(
-			&CHARLIE,
-			0,
-			AccountVote::Standard {
-				vote: Vote { nay: true, who: ALICE }
-			}
-		));
+		assert_eq!(ContinuumModule::get_map_spot(CONTINUUM_MAP_COORDINATE), Some(map_spot))
 	})
 }
 
 #[test]
-fn try_vote_should_fail_if_not_truly_neighbor() {
+fn create_buy_now_for_continuum_spot_should_fail_when_no_root() {
 	ExtBuilder::default().build().execute_with(|| {
-		let alice = Origin::signed(ALICE);
-		let bob = Origin::signed(BOB);
-
-		System::set_block_number(1);
-
-		// Alice & Bob register for slot 0,0
-		assert_ok!(ContinuumModule::register_interest(alice, ALICE_METAVERSE_ID, (0, 0)));
-		assert_ok!(ContinuumModule::register_interest(bob, BOB_METAVERSE_ID, (0, 0)));
-
-		run_to_block(10);
-		// Start auction slot on continuum
-		let auction_slot = AuctionSlot {
-			spot_id: 0,
-			participants: vec![ALICE, BOB],
-			active_session_index: 1,
-			status: ContinuumAuctionSlotStatus::AcceptParticipates,
-		};
-
-		let auction_slots: Vec<AuctionSlot<MBlockNumber, AccountId>> = vec![auction_slot];
-
-		let active_auctions: Option<Vec<AuctionSlot<MBlockNumber, AccountId>>> =
-			ContinuumModule::get_active_auction_slots(10);
-		match active_auctions {
-			Some(a) => {
-				// Verify EOI move to Auction Slots
-				assert_eq!(a[0].spot_id, auction_slots[0].spot_id);
-			}
-			_ => {
-				// Should fail test
-				assert_eq!(0, 1);
-			}
-		}
-
-		//Test starting GNP should work
-		run_to_block(20);
-		let gnp_started_auctions: Option<Vec<AuctionSlot<MBlockNumber, AccountId>>> =
-			ContinuumModule::get_active_gnp_slots(20);
-		match gnp_started_auctions {
-			Some(a) => {
-				// Verify Auction slots move to good neighborhood protocol Slots
-				assert_eq!(a[0].spot_id, a[0].spot_id);
-				assert_eq!(a[0].status, ContinuumAuctionSlotStatus::GNPStarted);
-
-				// Test start referendum should work
-				let status = ContinuumModule::referendum_status(0);
-				match status {
-					Ok(r) => {
-						assert_eq!(r.end, 30);
-					}
-					_ => {
-						assert_eq!(0, 1);
-					}
-				}
-			}
-			_ => {
-				// Should fail test
-				assert_eq!(0, 1);
-			}
-		}
-
-		// Try vote while referendum is active - Bob vote should be rejected
+		let root = Origin::root();
+		// Enable Allow BuyNow
+		assert_ok!(ContinuumModule::set_allow_buy_now(root.clone(), true));
+		assert_ok!(ContinuumModule::issue_map_slot(
+			root,
+			CONTINUUM_MAP_COORDINATE,
+			TokenType::Transferable
+		));
 		assert_noop!(
-			ContinuumModule::try_vote(
-				&CHARLIE,
-				0,
-				AccountVote::Standard {
-					vote: Vote { nay: true, who: BOB }
-				}
+			ContinuumModule::create_new_buy_now(
+				Origin::signed(ALICE),
+				CONTINUUM_MAP_COORDINATE,
+				AuctionType::BuyNow,
+				100,
+				10
 			),
-			Error::<Runtime>::NoPermission
+			BadOrigin
 		);
 	})
 }
 
 #[test]
-fn rotate_session_should_work() {
-	ExtBuilder::default().build().execute_with(|| {
-		let alice = Origin::signed(ALICE);
-		let bob = Origin::signed(BOB);
-
-		System::set_block_number(1);
-
-		assert_ok!(ContinuumModule::register_interest(alice, ALICE_METAVERSE_ID, (0, 0)));
-		assert_ok!(ContinuumModule::register_interest(bob, BOB_METAVERSE_ID, (0, 0)));
-
-		assert_ok!(ContinuumModule::set_allow_buy_now(Origin::root(), true));
-
-		run_to_block(10);
-
-		let auction_slot = AuctionSlot {
-			spot_id: 0,
-			participants: vec![ALICE, BOB],
-			active_session_index: 1,
-			status: ContinuumAuctionSlotStatus::AcceptParticipates,
-		};
-
-		let auction_slots: Vec<AuctionSlot<MBlockNumber, AccountId>> = vec![auction_slot];
-
-		let active_auctions: Option<Vec<AuctionSlot<MBlockNumber, AccountId>>> =
-			ContinuumModule::get_active_auction_slots(10);
-		match active_auctions {
-			Some(a) => {
-				// Verify EOI move to Auction Slots
-				assert_eq!(a[0].spot_id, auction_slots[0].spot_id);
-			}
-			_ => {
-				// Should fail test
-				assert_eq!(0, 1);
-			}
-		}
-
-		//Test starting GNP should work
-		run_to_block(20);
-		let gnp_started_auctions: Option<Vec<AuctionSlot<MBlockNumber, AccountId>>> =
-			ContinuumModule::get_active_gnp_slots(20);
-		match gnp_started_auctions {
-			Some(a) => {
-				// Verify Auction slots move to good neighborhood protocol Slots
-				assert_eq!(a[0].spot_id, a[0].spot_id);
-				assert_eq!(a[0].status, ContinuumAuctionSlotStatus::GNPStarted);
-
-				// Test start referendum should work
-				let status = ContinuumModule::referendum_status(0);
-				match status {
-					Ok(r) => {
-						assert_eq!(r.end, 30);
-					}
-					_ => {
-						assert_eq!(0, 1);
-					}
-				}
-			}
-			_ => {
-				// Should fail test
-				assert_eq!(0, 1);
-			}
-		}
-
-		// Try vote while referendum is active
-		assert_ok!(ContinuumModule::try_vote(
-			&CHARLIE,
-			0,
-			AccountVote::Standard {
-				vote: Vote { nay: true, who: ALICE }
-			}
-		));
-
-		// ALICE should be removed from participants list
-		// Conduct the referendum and finalise vote
-		run_to_block(30);
-
-		let finalised_votes: Option<Vec<AuctionSlot<MBlockNumber, AccountId>>> =
-			ContinuumModule::get_active_auction_slots(20);
-		match finalised_votes {
-			Some(v) => {
-				// Only BOB is eligible
-				assert_eq!(v[0].participants.len(), 1);
-				// Confirm if it's BOB
-				assert_eq!(v[0].participants[0], BOB);
-			}
-			_ => {}
-		}
-	})
-}
-
-#[test]
-fn buy_now_continuum_should_fail_when_not_owner() {
+fn create_buy_now_continuum_should_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		let root = Origin::root();
 
 		// Enable Allow BuyNow
-		assert_ok!(ContinuumModule::set_allow_buy_now(root, true));
+		assert_ok!(ContinuumModule::set_allow_buy_now(root.clone(), true));
+		assert_ok!(ContinuumModule::issue_map_slot(
+			root.clone(),
+			CONTINUUM_MAP_COORDINATE,
+			TokenType::Transferable
+		));
+
+		assert_ok!(ContinuumModule::create_new_buy_now(
+			root.clone(),
+			CONTINUUM_MAP_COORDINATE,
+			AuctionType::BuyNow,
+			100,
+			10
+		));
+	})
+}
+
+#[test]
+fn create_auction_continuum_should_work() {
+	ExtBuilder::default().build().execute_with(|| {
+		let root = Origin::root();
+
+		// Enable Allow BuyNow
+		assert_ok!(ContinuumModule::set_allow_buy_now(root.clone(), true));
+		assert_ok!(ContinuumModule::issue_map_slot(
+			root.clone(),
+			CONTINUUM_MAP_COORDINATE,
+			TokenType::Transferable
+		));
+
+		assert_ok!(ContinuumModule::create_new_buy_now(
+			root.clone(),
+			CONTINUUM_MAP_COORDINATE,
+			AuctionType::Auction,
+			100,
+			10
+		));
 	})
 }
 
@@ -332,12 +159,26 @@ fn buy_now_continuum_should_work() {
 		let root = Origin::root();
 
 		// Enable Allow BuyNow
-		assert_ok!(ContinuumModule::set_allow_buy_now(root, true));
-		let continuum_spot_1 = ContinuumModule::get_continuum_spot(0);
+		assert_ok!(ContinuumModule::set_allow_buy_now(root.clone(), true));
+		assert_ok!(ContinuumModule::issue_map_slot(
+			root.clone(),
+			CONTINUUM_MAP_COORDINATE,
+			TokenType::Transferable
+		));
 
-		assert_eq!(ContinuumModule::get_continuum_position((0, 1)), 0);
-		assert_eq!(ContinuumModule::get_continuum_position((0, 2)), 1);
+		assert_ok!(ContinuumModule::create_new_buy_now(
+			root.clone(),
+			CONTINUUM_MAP_COORDINATE,
+			AuctionType::BuyNow,
+			100,
+			10
+		));
 
-		assert_eq!(continuum_spot_1.metaverse_id, ALICE_METAVERSE_ID)
+		assert_ok!(ContinuumModule::buy_map_spot(
+			Origin::signed(ALICE),
+			1,
+			100,
+			ALICE_METAVERSE_ID
+		));
 	})
 }

--- a/pallets/continuum/src/types.rs
+++ b/pallets/continuum/src/types.rs
@@ -17,14 +17,17 @@
 
 //! Miscellaneous additional datatypes.
 
-use crate::{AccountVote, Vote};
 use codec::{Decode, Encode};
-use primitives::{MetaverseId, SpotId};
 use scale_info::TypeInfo;
 use sp_runtime::traits::{One, Zero};
 use sp_runtime::{DispatchError, RuntimeDebug};
 use sp_std::vec;
 use sp_std::vec::Vec;
+
+use core_primitives::TokenType;
+use primitives::{MetaverseId, SpotId};
+
+use crate::{AccountVote, Vote};
 
 pub type ReferendumIndex = u64;
 
@@ -34,6 +37,14 @@ pub struct ContinuumSpot {
 	pub(crate) x: i32,
 	pub(crate) y: i32,
 	pub(crate) metaverse_id: MetaverseId,
+}
+
+/// MapSpot Struct
+#[derive(Encode, Decode, Default, Clone, PartialEq, Eq, RuntimeDebug, TypeInfo)]
+pub struct MapSpot<AccountId> {
+	pub metaverse_id: Option<MetaverseId>,
+	pub owner: AccountId,
+	pub slot_type: TokenType,
 }
 
 impl ContinuumSpot {

--- a/pallets/economy/src/mock.rs
+++ b/pallets/economy/src/mock.rs
@@ -11,7 +11,7 @@ use auction_manager::*;
 use core_primitives::NftAssetData;
 use primitives::estate::Estate;
 use primitives::staking::MetaverseStakingTrait;
-use primitives::{Amount, EstateId, FungibleTokenId, ItemId, UndeployedLandBlockId};
+use primitives::{Amount, AuctionId, EstateId, FungibleTokenId, ItemId, UndeployedLandBlockId};
 
 use crate as economy;
 
@@ -244,7 +244,15 @@ impl Auction<AccountId, BlockNumber> for MockAuctionManager {
 		None
 	}
 
+	fn auction_item(id: AuctionId) -> Option<AuctionItem<AccountId, BlockNumber, Self::Balance>> {
+		None
+	}
+
 	fn update_auction(_id: u64, _info: AuctionInfo<u128, Self::Balance, u64>) -> DispatchResult {
+		Ok(())
+	}
+
+	fn update_auction_item(id: AuctionId, item_id: ItemId<Self::Balance>) -> DispatchResult {
 		Ok(())
 	}
 
@@ -272,12 +280,11 @@ impl Auction<AccountId, BlockNumber> for MockAuctionManager {
 
 	fn remove_auction(_id: u64, _item_id: ItemId<Balance>) {}
 
-	fn auction_bid_handler(
-		_now: u64,
-		_id: u64,
-		_new_bid: (u128, Self::Balance),
-		_last_bid: Option<(u128, Self::Balance)>,
-	) -> DispatchResult {
+	fn auction_bid_handler(from: AccountId, id: AuctionId, value: Self::Balance) -> DispatchResult {
+		Ok(())
+	}
+
+	fn buy_now_handler(from: AccountId, auction_id: AuctionId, value: Self::Balance) -> DispatchResult {
 		Ok(())
 	}
 

--- a/pallets/estate/src/mock.rs
+++ b/pallets/estate/src/mock.rs
@@ -7,10 +7,10 @@ use sp_runtime::{testing::Header, traits::IdentityLookup, DispatchError, Perbill
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::default::Default;
 
-use auction_manager::{Auction, AuctionInfo, AuctionType, CheckAuctionItemHandler, ListingLevel};
+use auction_manager::{Auction, AuctionInfo, AuctionItem, AuctionType, CheckAuctionItemHandler, ListingLevel};
 use core_primitives::{CollectionType, NftClassData, TokenType};
 use primitives::{
-	AssetId, Attributes, ClassId, FungibleTokenId, GroupCollectionId, NftMetadata, TokenId, LAND_CLASS_ID,
+	AssetId, Attributes, AuctionId, ClassId, FungibleTokenId, GroupCollectionId, NftMetadata, TokenId, LAND_CLASS_ID,
 };
 
 use crate as estate;
@@ -196,7 +196,15 @@ impl Auction<AccountId, BlockNumber> for MockAuctionManager {
 		None
 	}
 
+	fn auction_item(id: AuctionId) -> Option<AuctionItem<AccountId, BlockNumber, Self::Balance>> {
+		None
+	}
+
 	fn update_auction(_id: u64, _info: AuctionInfo<u128, Self::Balance, u64>) -> DispatchResult {
+		Ok(())
+	}
+
+	fn update_auction_item(id: AuctionId, item_id: ItemId<Self::Balance>) -> DispatchResult {
 		Ok(())
 	}
 
@@ -224,12 +232,11 @@ impl Auction<AccountId, BlockNumber> for MockAuctionManager {
 
 	fn remove_auction(_id: u64, _item_id: ItemId<Balance>) {}
 
-	fn auction_bid_handler(
-		_now: u64,
-		_id: u64,
-		_new_bid: (u128, Self::Balance),
-		_last_bid: Option<(u128, Self::Balance)>,
-	) -> DispatchResult {
+	fn auction_bid_handler(from: AccountId, id: AuctionId, value: Self::Balance) -> DispatchResult {
+		Ok(())
+	}
+
+	fn buy_now_handler(from: AccountId, auction_id: AuctionId, value: Self::Balance) -> DispatchResult {
 		Ok(())
 	}
 

--- a/pallets/nft/src/mock.rs
+++ b/pallets/nft/src/mock.rs
@@ -10,9 +10,9 @@ use sp_runtime::testing::Header;
 use sp_runtime::traits::IdentityLookup;
 use sp_runtime::Perbill;
 
-use auction_manager::{Auction, AuctionInfo, AuctionType, ListingLevel};
+use auction_manager::{Auction, AuctionInfo, AuctionItem, AuctionType, ListingLevel};
 pub use primitive_traits::{CollectionType, NftAssetData, NftClassData};
-use primitives::{Amount, CurrencyId, FungibleTokenId, ItemId};
+use primitives::{Amount, AuctionId, CurrencyId, FungibleTokenId, ItemId};
 
 use crate as nft;
 
@@ -95,7 +95,15 @@ impl Auction<AccountId, BlockNumber> for MockAuctionManager {
 		None
 	}
 
+	fn auction_item(id: AuctionId) -> Option<AuctionItem<AccountId, BlockNumber, Self::Balance>> {
+		None
+	}
+
 	fn update_auction(_id: u64, _info: AuctionInfo<u128, Self::Balance, u64>) -> DispatchResult {
+		Ok(())
+	}
+
+	fn update_auction_item(id: AuctionId, item_id: ItemId<Self::Balance>) -> DispatchResult {
 		Ok(())
 	}
 
@@ -123,12 +131,11 @@ impl Auction<AccountId, BlockNumber> for MockAuctionManager {
 
 	fn remove_auction(_id: u64, _item_id: ItemId<Balance>) {}
 
-	fn auction_bid_handler(
-		_now: u64,
-		_id: u64,
-		_new_bid: (u128, Self::Balance),
-		_last_bid: Option<(u128, Self::Balance)>,
-	) -> DispatchResult {
+	fn auction_bid_handler(from: AccountId, id: AuctionId, value: Self::Balance) -> DispatchResult {
+		Ok(())
+	}
+
+	fn buy_now_handler(from: AccountId, auction_id: AuctionId, value: Self::Balance) -> DispatchResult {
 		Ok(())
 	}
 

--- a/primitives/metaverse/src/continuum.rs
+++ b/primitives/metaverse/src/continuum.rs
@@ -3,5 +3,9 @@ use sp_runtime::DispatchError;
 use crate::{MapSpotId, MetaverseId, SpotId};
 
 pub trait MapTrait<AccountId> {
-	fn transfer_spot(spot_id: MapSpotId, from: &AccountId, to: &AccountId) -> Result<MapSpotId, DispatchError>;
+	fn transfer_spot(
+		spot_id: MapSpotId,
+		from: AccountId,
+		to: (AccountId, MetaverseId),
+	) -> Result<MapSpotId, DispatchError>;
 }

--- a/primitives/metaverse/src/continuum.rs
+++ b/primitives/metaverse/src/continuum.rs
@@ -1,7 +1,7 @@
-use crate::{MetaverseId, SpotId};
 use sp_runtime::DispatchError;
 
-pub trait Continuum<AccountId> {
-	fn transfer_spot(spot_id: SpotId, from: &AccountId, to: &(AccountId, MetaverseId))
-		-> Result<SpotId, DispatchError>;
+use crate::{MapSpotId, MetaverseId, SpotId};
+
+pub trait MapTrait<AccountId> {
+	fn transfer_spot(spot_id: MapSpotId, from: &AccountId, to: &AccountId) -> Result<MapSpotId, DispatchError>;
 }

--- a/primitives/metaverse/src/lib.rs
+++ b/primitives/metaverse/src/lib.rs
@@ -92,6 +92,8 @@ pub type NftId = u64;
 pub type AuctionId = u64;
 /// SpotId
 pub type SpotId = u64;
+/// MapSpotId
+pub type MapSpotId = (i32, i32);
 /// ProposalId
 pub type ProposalId = u64;
 /// ReferendumId
@@ -131,7 +133,7 @@ pub const ESTATE_CLASS_ID: ClassId = 16;
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum ItemId<Balance> {
 	NFT(ClassId, TokenId),
-	Spot(u64, MetaverseId),
+	Spot(MapSpotId),
 	Metaverse(MetaverseId),
 	Block(u64),
 	Estate(EstateId),

--- a/primitives/metaverse/src/lib.rs
+++ b/primitives/metaverse/src/lib.rs
@@ -133,13 +133,26 @@ pub const ESTATE_CLASS_ID: ClassId = 16;
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum ItemId<Balance> {
 	NFT(ClassId, TokenId),
-	Spot(MapSpotId),
+	Spot(MapSpotId, MetaverseId),
 	Metaverse(MetaverseId),
 	Block(u64),
 	Estate(EstateId),
 	LandUnit((i32, i32), MetaverseId),
 	Bundle(Vec<(ClassId, TokenId, Balance)>),
 	UndeployedLandBlock(UndeployedLandBlockId),
+}
+
+impl<Balance: AtLeast32Bit + Copy> ItemId<Balance> {
+	pub fn is_map_spot(&self) -> bool {
+		matches!(self, FungibleTokenId::Spot(_, _))
+	}
+
+	pub fn get_map_spot_detail(&self) -> Option<(&MapSpotId, &MetaverseId)> {
+		match self {
+			ItemId::Spot(spot_id, metaverse_id) => Some((spot_id, metaverse_id)),
+			_ => None,
+		}
+	}
 }
 
 #[derive(Encode, Decode, Eq, PartialEq, Copy, Clone, RuntimeDebug, MaxEncodedLen, PartialOrd, Ord, TypeInfo)]

--- a/primitives/metaverse/src/lib.rs
+++ b/primitives/metaverse/src/lib.rs
@@ -144,7 +144,7 @@ pub enum ItemId<Balance> {
 
 impl<Balance: AtLeast32Bit + Copy> ItemId<Balance> {
 	pub fn is_map_spot(&self) -> bool {
-		matches!(self, FungibleTokenId::Spot(_, _))
+		matches!(self, ItemId::Spot(_, _))
 	}
 
 	pub fn get_map_spot_detail(&self) -> Option<(&MapSpotId, &MetaverseId)> {

--- a/traits/auction-manager/src/lib.rs
+++ b/traits/auction-manager/src/lib.rs
@@ -127,12 +127,7 @@ pub trait Auction<AccountId, BlockNumber> {
 	/// Remove auction by `id`
 	fn remove_auction(id: AuctionId, item_id: ItemId<Self::Balance>);
 
-	fn auction_bid_handler(
-		_now: BlockNumber,
-		id: AuctionId,
-		new_bid: (AccountId, Self::Balance),
-		last_bid: Option<(AccountId, Self::Balance)>,
-	) -> DispatchResult;
+	fn auction_bid_handler(from: AccountId, id: AuctionId, value: Self::Balance) -> DispatchResult;
 
 	fn buy_now_handler(from: AccountId, auction_id: AuctionId, value: Self::Balance) -> DispatchResult;
 

--- a/traits/auction-manager/src/lib.rs
+++ b/traits/auction-manager/src/lib.rs
@@ -94,8 +94,16 @@ pub trait Auction<AccountId, BlockNumber> {
 
 	/// The auction info of `id`
 	fn auction_info(id: AuctionId) -> Option<AuctionInfo<AccountId, Self::Balance, BlockNumber>>;
+
+	/// The auction item of `id`
+	fn auction_item(id: AuctionId) -> Option<AuctionItem<AccountId, Self::Balance, BlockNumber>>;
+
 	/// Update the auction info of `id` with `info`
 	fn update_auction(id: AuctionId, info: AuctionInfo<AccountId, Self::Balance, BlockNumber>) -> DispatchResult;
+
+	/// Update auction item of `id` with new `item_id`
+	fn update_auction_item(id: AuctionId, item_id: ItemId<Self::Balance>) -> DispatchResult;
+
 	/// Create new auction with specific startblock and endblock, return the id
 	/// of the auction
 	fn new_auction(
@@ -125,6 +133,8 @@ pub trait Auction<AccountId, BlockNumber> {
 		new_bid: (AccountId, Self::Balance),
 		last_bid: Option<(AccountId, Self::Balance)>,
 	) -> DispatchResult;
+
+	fn buy_now_handler(from: AccountId, auction_id: AuctionId, value: (AccountId, Self::Balance)) -> DispatchResult;
 
 	fn local_auction_bid_handler(
 		_now: BlockNumber,

--- a/traits/auction-manager/src/lib.rs
+++ b/traits/auction-manager/src/lib.rs
@@ -96,7 +96,7 @@ pub trait Auction<AccountId, BlockNumber> {
 	fn auction_info(id: AuctionId) -> Option<AuctionInfo<AccountId, Self::Balance, BlockNumber>>;
 
 	/// The auction item of `id`
-	fn auction_item(id: AuctionId) -> Option<AuctionItem<AccountId, Self::Balance, BlockNumber>>;
+	fn auction_item(id: AuctionId) -> Option<AuctionItem<AccountId, BlockNumber, Self::Balance>>;
 
 	/// Update the auction info of `id` with `info`
 	fn update_auction(id: AuctionId, info: AuctionInfo<AccountId, Self::Balance, BlockNumber>) -> DispatchResult;
@@ -134,7 +134,7 @@ pub trait Auction<AccountId, BlockNumber> {
 		last_bid: Option<(AccountId, Self::Balance)>,
 	) -> DispatchResult;
 
-	fn buy_now_handler(from: AccountId, auction_id: AuctionId, value: (AccountId, Self::Balance)) -> DispatchResult;
+	fn buy_now_handler(from: AccountId, auction_id: AuctionId, value: Self::Balance) -> DispatchResult;
 
 	fn local_auction_bid_handler(
 		_now: BlockNumber,


### PR DESCRIPTION
This PR is the re-work of the continuum map engine, which allows the council/proposal to issue new map spot instead of automated release every round which causes the inflated map slot. 

The improvement logic: council issuing new map spot and auction slot, the on-going auction slot can be bidded by metaverse owner only. Once it's secured, the slot will be assigned to that metaverse.

- [x] Rework on continuum map trait
- [x] Implement new extrinsics for issuing new slot, creating new auction slot.
- [x] Auction finality specialised for MapSlot
- [ ] Extends end time when entering critical period. - Extend for next release
- [x] Implement unit tests to ensure all logic well tested.
- [x] Storage migration if required