### PR TITLE
Dynamically calculate royalty fee of bundle according to bid price

### DIFF
--- a/pallets/auction/src/lib.rs
+++ b/pallets/auction/src/lib.rs
@@ -1574,6 +1574,20 @@ pub mod pallet {
 				// Lock fund of new bidder
 				// Reserve balance
 				<T as Config>::Currency::reserve(&new_bidder, new_bid_price)?;
+
+				// Update new bid price for individual item on bundle
+				if let ItemId::Bundle(tokens) = &auction_item.item_id {
+					let mut new_bundle: Vec<(ClassId, TokenId, BalanceOf<T>)> = Vec::new();
+					let total_amount = auction_item.amount.clone();
+
+					for token in tokens {
+						let new_price: BalanceOf<T> = Perbill::from_rational(token.2, total_amount) * new_bid_price;
+						new_bundle.push((token.0, token.1, new_price))
+					}
+
+					auction_item.item_id = ItemId::Bundle(new_bundle);
+				}
+
 				auction_item.amount = new_bid_price.clone();
 
 				Ok(())

--- a/pallets/auction/src/lib.rs
+++ b/pallets/auction/src/lib.rs
@@ -1584,7 +1584,8 @@ pub mod pallet {
 						let new_price: BalanceOf<T> = Perbill::from_rational(token.2, total_amount) * new_bid_price;
 						new_bundle.push((token.0, token.1, new_price))
 					}
-
+					ItemsInAuction::<T>::remove(ItemId::Bundle(tokens.clone()));
+					ItemsInAuction::<T>::insert(ItemId::Bundle(new_bundle.clone()), true);
 					auction_item.item_id = ItemId::Bundle(new_bundle);
 				}
 

--- a/pallets/auction/src/tests.rs
+++ b/pallets/auction/src/tests.rs
@@ -1256,6 +1256,16 @@ fn on_finalize_with_bundle_with_listing_fee_should_work() {
 			Some(true)
 		);
 		assert_ok!(AuctionModule::bid(bidder, 0, 400));
+		// asset is not longer in auction
+		assert_eq!(AuctionModule::items_in_auction(ItemId::Bundle(tokens.clone())), None);
+		// 400 will split to 2 nfts according to percentage
+		let updated_token_with_price = vec![(0, 0, 160), (0, 1, 240)];
+		// check latest updated item_id
+		assert_eq!(
+			AuctionModule::items_in_auction(ItemId::Bundle(updated_token_with_price)),
+			Some(true)
+		);
+
 		// Free balance of Alice is 99994 - 1 (network reserve fee)
 		assert_eq!(Balances::free_balance(ALICE), 99993);
 		run_to_block(102);
@@ -1270,8 +1280,6 @@ fn on_finalize_with_bundle_with_listing_fee_should_work() {
 		// Cost breakdown 400 - 4 (royalty) - 4 (1% network fee) - 40 (listing fee) = 352
 		// Free balance of Alice is 99994 + 352 = 100346
 		assert_eq!(Balances::free_balance(ALICE), 100346);
-		// asset is not longer in auction
-		assert_eq!(AuctionModule::items_in_auction(ItemId::Bundle(tokens.clone())), None);
 		// event was triggered
 		let event = mock::Event::AuctionModule(crate::Event::AuctionFinalized(0, BOB, 400));
 		assert_eq!(last_event(), event);

--- a/pallets/auction/src/tests.rs
+++ b/pallets/auction/src/tests.rs
@@ -1191,6 +1191,44 @@ fn on_finalize_with_listing_fee_should_work() {
 }
 
 #[test]
+fn auction_bundle_should_update_new_price_according_new_bid() {
+	ExtBuilder::default().build().execute_with(|| {
+		let owner = Origin::signed(ALICE);
+		let bidder = Origin::signed(BOB);
+		init_test_nft(owner.clone());
+		init_test_nft(owner.clone());
+
+		// After minting new NFTs, it costs 6 unit
+		assert_eq!(Balances::free_balance(ALICE), 99994);
+
+		let tokens = vec![(0, 0, 100), (0, 1, 100)];
+		assert_ok!(AuctionModule::create_auction(
+			AuctionType::Auction,
+			ItemId::Bundle(tokens.clone()),
+			None,
+			ALICE,
+			200,
+			0,
+			ListingLevel::Local(ALICE_METAVERSE_ID),
+			Perbill::from_percent(10u32)
+		));
+		assert_eq!(
+			AuctionModule::items_in_auction(ItemId::Bundle(tokens.clone())),
+			Some(true)
+		);
+		assert_ok!(AuctionModule::bid(bidder, 0, 300));
+		// Free balance of Alice is 99994 - 1 (network reserve fee)
+		assert_eq!(Balances::free_balance(ALICE), 99993);
+
+		let tokens_after_bid = vec![(0, 0, 150), (0, 1, 150)];
+		let item_updated_after_bid = AuctionModule::items_in_auction(ItemId::Bundle(tokens.clone()));
+		let auction_item = AuctionModule::get_auction_item(0).unwrap();
+
+		assert_eq!(auction_item.item_id, ItemId::Bundle(tokens_after_bid));
+	})
+}
+
+#[test]
 // Auction finalize with bundle and listing fee works
 fn on_finalize_with_bundle_with_listing_fee_should_work() {
 	ExtBuilder::default().build().execute_with(|| {
@@ -1217,24 +1255,25 @@ fn on_finalize_with_bundle_with_listing_fee_should_work() {
 			AuctionModule::items_in_auction(ItemId::Bundle(tokens.clone())),
 			Some(true)
 		);
-		assert_ok!(AuctionModule::bid(bidder, 0, 200));
+		assert_ok!(AuctionModule::bid(bidder, 0, 400));
 		// Free balance of Alice is 99994 - 1 (network reserve fee)
 		assert_eq!(Balances::free_balance(ALICE), 99993);
 		run_to_block(102);
 		assert_eq!(AuctionModule::auctions(0), None);
 		// check account received asset
 		assert_eq!(NFTModule::<Runtime>::check_ownership(&BOB, &(0, 0)), Ok(true));
+		assert_eq!(NFTModule::<Runtime>::check_ownership(&BOB, &(0, 1)), Ok(true));
 		// check balances were transferred
-		// Bob bid 200 for item, his new balance will be 500 - 200
-		assert_eq!(Balances::free_balance(BOB), 300);
+		// Bob bid 400 for item, his new balance will be 500 - 400
+		assert_eq!(Balances::free_balance(BOB), 100);
 		// Alice only receive 176 for item solds
-		// Cost breakdown 200 - 2 (royalty) - 2 (1% network fee) - 20 (listing fee)
-		// Free balance of Alice is 99994 + 176 = 100170
-		assert_eq!(Balances::free_balance(ALICE), 100170);
+		// Cost breakdown 400 - 4 (royalty) - 4 (1% network fee) - 40 (listing fee) = 352
+		// Free balance of Alice is 99994 + 352 = 100346
+		assert_eq!(Balances::free_balance(ALICE), 100346);
 		// asset is not longer in auction
 		assert_eq!(AuctionModule::items_in_auction(ItemId::Bundle(tokens.clone())), None);
 		// event was triggered
-		let event = mock::Event::AuctionModule(crate::Event::AuctionFinalized(0, BOB, 200));
+		let event = mock::Event::AuctionModule(crate::Event::AuctionFinalized(0, BOB, 400));
 		assert_eq!(last_event(), event);
 	});
 }


### PR DESCRIPTION
Issue: when a new bid happens on the bundle, the royalty fee of individual NFT is only calculated based on the initial price setting. This could be a loss for NFT creators if the initial and final prices are big differences. 

This implementation will ensure the price set up for individual NFTs will be updated when a new bid is accepted. Royalty collection process will take the fees according to the latest price set up on every bid.
